### PR TITLE
Adhoc test case for streaming a file

### DIFF
--- a/servant-streaming-server/test/Servant/Streaming/ServerSpec.hs
+++ b/servant-streaming-server/test/Servant/Streaming/ServerSpec.hs
@@ -97,15 +97,13 @@ streamResponseSpec = describe "StreamResponse instance" $ around withServer $ do
         req = req' { requestHeaders = ("Accept", "bla/bla"):requestHeaders req' }
     responseStatus <$> makeRequest req `shouldReturn` status406
 
-  it "streams a huge file as response body" $ \port' -> do
+  it "handles resource deallocation correctly" $ \port' -> do
     let req' = streamReq port' "getfile" (S.each []) -- TODO: simplify
-        bigfile :: IsString a => a
-        bigfile = "foobar" -- TODO: 100MB file
-    BS.writeFile "hello.txt" bigfile -- TODO: temporary file
+        contents :: IsString a => a
+        contents = "foobar"
+    BS.writeFile "hello.txt" contents -- TODO: temporary file
     responseBody <$> makeRequest req'
-        `shouldReturn` fromString bigfile -- TODO: use another file as destination?
-    bytes <- max_live_bytes <$> getRTSStats
-    bytes < 100 * megabyte `shouldBe` True
+        `shouldReturn` fromString contents
 
 ------------------------------------------------------------------------------
 -- API

--- a/servant-streaming-server/test/Servant/Streaming/ServerSpec.hs
+++ b/servant-streaming-server/test/Servant/Streaming/ServerSpec.hs
@@ -6,10 +6,12 @@ import           Control.Concurrent
 import           Control.Monad.Trans.Resource (ResourceT, getInternalState,
                                                runInternalState, runResourceT)
 import           Data.ByteString              (ByteString)
+import qualified Data.ByteString.Streaming    as BSS
 import qualified Data.ByteString              as BS
 import qualified Data.ByteString.Lazy         as BSL
+
 import           Data.IORef
-import           Data.String                  (fromString)
+import           Data.String                  (fromString, IsString)
 import           GHC.Stats
 import qualified Network.HTTP.Media           as M
 import           Network.HTTP.Types           (status200, status405, status406,
@@ -95,6 +97,16 @@ streamResponseSpec = describe "StreamResponse instance" $ around withServer $ do
         req = req' { requestHeaders = ("Accept", "bla/bla"):requestHeaders req' }
     responseStatus <$> makeRequest req `shouldReturn` status406
 
+  it "streams a huge file as response body" $ \port' -> do
+    let req' = streamReq port' "getfile" (S.each []) -- TODO: simplify
+        bigfile :: IsString a => a
+        bigfile = "foobar" -- TODO: 100MB file
+    BS.writeFile "hello.txt" bigfile -- TODO: temporary file
+    responseBody <$> makeRequest req'
+        `shouldReturn` fromString bigfile -- TODO: use another file as destination?
+    bytes <- max_live_bytes <$> getRTSStats
+    bytes < 100 * megabyte `shouldBe` True
+
 ------------------------------------------------------------------------------
 -- API
 
@@ -102,12 +114,13 @@ type API
   =    "length" :> StreamBody '[JSON] :> Post '[PlainText] Int
   :<|> "contentType" :> StreamBody '[JSON, PlainText] :> Post '[PlainText] M.MediaType
   :<|> "echo" :> StreamBody '[JSON] :> StreamResponsePost '[JSON]
+  :<|> "getfile" :> StreamResponsePost '[PlainText]
 
 api :: Proxy API
 api = Proxy
 
 server :: Server API
-server = lengthH :<|> contentTypeH :<|> echoH
+server = lengthH :<|> contentTypeH :<|> echoH :<|> getfileH
   where
     lengthH      (_contentType, stream')
       = liftIO . runResourceT $ S.sum_ $ S.subst (\x -> BS.length x :> ()) stream'
@@ -115,6 +128,7 @@ server = lengthH :<|> contentTypeH :<|> echoH
       = return contentType
     echoH        (_contentType, stream')
       = return stream'
+    getfileH = return $ BSS.toChunks (BSS.readFile "hello.txt")
 
 withServer :: (Port -> IO ()) -> IO ()
 withServer = withApplicationSettings settings (return $ serve api server)


### PR DESCRIPTION
```
Failures:                                                       
                                                                 
  test/Servant/Streaming/ServerSpec.hs:106:                
  1) Servant.Streaming.Server, StreamResponse instance, streams a 
huge file as response body                                               expected: "foobar"                     
        but got: ""     
```

In tests I don't see the output, but with an example
serving the API I also see:

```
 hello.txt: hGetBufSome: illegal operation (handle is closed)
```

cc @jkarni this is a test case for what we discussed yesterday on #servant
