### PR TITLE
stackage: 10.6 -> 11.1

### DIFF
--- a/servant-streaming-client/servant-streaming-client.cabal
+++ b/servant-streaming-client/servant-streaming-client.cabal
@@ -33,7 +33,7 @@ library
     , bytestring
     , http-media >=0.6 && <0.8
     , http-types >=0.9 && <0.13
-    , resourcet >=1.1 && <1.2
+    , resourcet >=1.1 && <1.3
     , servant >=0.10 && <0.14
     , servant-client-core >=0.10 && <0.14
     , servant-streaming <0.2
@@ -58,7 +58,7 @@ test-suite spec
     , http-client
     , http-media >=0.6 && <0.8
     , http-types >=0.9 && <0.13
-    , resourcet >=1.1 && <1.2
+    , resourcet >=1.1 && <1.3
     , servant >=0.10 && <0.14
     , servant-client
     , servant-client-core >=0.10 && <0.14

--- a/servant-streaming-server/servant-streaming-server.cabal
+++ b/servant-streaming-server/servant-streaming-server.cabal
@@ -33,7 +33,7 @@ library
     , bytestring
     , http-media >=0.6 && <0.8
     , http-types >=0.9 && <0.13
-    , resourcet >=1.1 && <1.2
+    , resourcet >=1.1 && <1.3
     , servant
     , servant-server >=0.8 && <0.14
     , servant-streaming <0.2
@@ -61,7 +61,7 @@ test-suite spec
     , http-types >=0.9 && <0.13
     , pipes >=4 && <5
     , pipes-http >=1 && <2
-    , resourcet >=1.1 && <1.2
+    , resourcet >=1.1 && <1.3
     , servant
     , servant-server >=0.8 && <0.14
     , servant-streaming <0.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,22 +1,17 @@
-resolver: lts-10.6
+resolver: lts-11.1
 packages:
 - servant-streaming/
 - servant-streaming-server/
 - servant-streaming-client/
 - servant-streaming-docs/
 extra-deps:
-- streaming-0.2.0.0
 - streaming-wai-0.1.1
 - pipes-http-1.0.5
 - git: https://github.com/haskell-servant/servant
-  commit: bb49f90ba2815e27f781766a887dca8c1f6d8d89
+  commit: e3158d70168ab0087c867e9f9761d2aff2b01182
   subdirs:
     - servant-server
     - servant
     - servant-client-core
     - servant-client
     - servant-docs
-- text-1.2.3.0
-- http-types-0.12.1
-flags: {}
-extra-package-dbs: []


### PR DESCRIPTION
also bump servant-client to include missing constructor.

cc @jkarni 