### PR TITLE
Custom server monad for StreamBody

### DIFF
--- a/servant-streaming-client/package.yaml
+++ b/servant-streaming-client/package.yaml
@@ -23,7 +23,7 @@ dependencies:
   - servant-streaming < 0.2
   - bytestring
   - servant-client-core >= 0.10 && < 0.14
-  - resourcet >= 1.1 && < 1.2
+  - resourcet >= 1.1 && < 1.3
   - streaming >= 0.1 && < 0.3
 
 

--- a/servant-streaming-client/src/Servant/Streaming/Client/Internal.hs
+++ b/servant-streaming-client/src/Servant/Streaming/Client/Internal.hs
@@ -15,9 +15,9 @@ import           Servant.Streaming
 import           Streaming
 import qualified Streaming.Prelude            as S
 
-instance (HasClient m subapi, RunClient m )
-    => HasClient m (StreamBody contentTypes :> subapi) where
-  type Client m (StreamBody contentTypes :> subapi)
+instance (HasClient m subapi, RunClient m)
+    => HasClient m (StreamBodyMonad contentTypes n :> subapi) where
+  type Client m (StreamBodyMonad contentTypes n :> subapi)
     = (M.MediaType, Stream (Of BS.ByteString) (ResourceT IO) ())
       -> Client m subapi
   clientWithRoute pm _ req (mtype, body)

--- a/servant-streaming-server/package.yaml
+++ b/servant-streaming-server/package.yaml
@@ -18,7 +18,7 @@ ghc-options: -Wall
 dependencies:
   - base >= 4.7 && < 4.11
   - bytestring
-  - resourcet >= 1.1 && < 1.2
+  - resourcet >= 1.1 && < 1.3
   - servant
   - servant-server >= 0.8 && < 0.14
   - servant-streaming < 0.2

--- a/servant-streaming-server/src/Servant/Streaming/Server/Internal.hs
+++ b/servant-streaming-server/src/Servant/Streaming/Server/Internal.hs
@@ -37,10 +37,10 @@ import           Servant.Server.Internal.RoutingApplication (DelayedIO,
 import           Servant.Streaming
 import           Streaming
 
-instance ( AllMime contentTypes, HasServer subapi ctx
-         ) => HasServer (StreamBody contentTypes :> subapi) ctx where
-  type ServerT (StreamBody contentTypes :> subapi) m
-    = (M.MediaType, Stream (Of BS.ByteString) (ResourceT IO) ())
+instance ( AllMime contentTypes, HasServer subapi ctx, MonadIO n
+         ) => HasServer (StreamBodyMonad contentTypes n :> subapi) ctx where
+  type ServerT (StreamBodyMonad contentTypes n :> subapi) m
+    = (M.MediaType, Stream (Of BS.ByteString) (ResourceT n) ())
       -> ServerT subapi m
 
   route _ ctxt subapi =

--- a/servant-streaming/src/Servant/Streaming.hs
+++ b/servant-streaming/src/Servant/Streaming.hs
@@ -4,7 +4,10 @@ import GHC.TypeLits (Nat)
 import Network.HTTP.Types
 
 -- | A request body that should be streamed.
-data StreamBody (contentTypes :: [*])
+type StreamBody ct = StreamBodyMonad ct IO
+
+-- | A request body that should be streamed with specified server monad
+data StreamBodyMonad (contentTypes :: [*]) (m :: * -> *)
 
 -- | A response body that should be streamed, with specified method, status,
 -- and content-type.

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ extra-deps:
 - streaming-wai-0.1.1
 - pipes-http-1.0.5
 - git: https://github.com/haskell-servant/servant
-  commit: e3158d70168ab0087c867e9f9761d2aff2b01182
+  commit: 0c66b9c0559721ea682cd0d1fa35f403ec075cda
   subdirs:
     - servant-server
     - servant


### PR DESCRIPTION
Fixes #6 for my use case, although I don't like the naming `StreamBodyMonad`.

Based on #5 

Better solution would be polymorphic `m` with constraint `MonadIO m`, but I couldn't figure out how to implement that.