### PR TITLE
HasLink instances

### DIFF
--- a/servant-streaming/src/Servant/Streaming.hs
+++ b/servant-streaming/src/Servant/Streaming.hs
@@ -1,7 +1,10 @@
 module Servant.Streaming where
 
+import Data.Proxy (Proxy (..))
 import GHC.TypeLits (Nat)
 import Network.HTTP.Types
+import Servant.API ((:>))
+import Servant.Utils.Links (HasLink (..), Link, MkLink)
 
 -- | A request body that should be streamed.
 type StreamBody ct = StreamBodyMonad ct IO
@@ -24,3 +27,11 @@ type StreamResponsePut = StreamResponse 'PUT 200
 
 -- | The streaming version of the @Patch@ combinator.
 type StreamResponsePatch = StreamResponse 'PATCH 200
+
+instance HasLink sub => HasLink (StreamBody ct :> sub) where
+    type MkLink (StreamBody ct :> sub) r = MkLink sub r
+    toLink toA _ = toLink toA (Proxy :: Proxy sub)
+
+instance HasLink (StreamResponse method status ct) where
+    type MkLink (StreamResponse method status ct) r = r
+    toLink toA _ = toA


### PR DESCRIPTION
Permit the use of `safeLink` with endpoints containing `StreamBody` or `StreamResponse`. The instances are the same as those for `ReqBody` and `Verb` respectively.