### PR TITLE
Bump servant and base requirements

### DIFF
--- a/servant-streaming-client/package.yaml
+++ b/servant-streaming-client/package.yaml
@@ -16,13 +16,13 @@ tested-with:         GHC == 8.2.2
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.7 && < 4.11
+  - base >= 4.7 && < 4.12
   - http-types >= 0.9 && < 0.13
   - http-media >= 0.6 && < 0.8
-  - servant >= 0.10 && < 0.15
+  - servant >= 0.14 && < 0.15
   - servant-streaming >= 0.2 && < 0.3
   - bytestring
-  - servant-client-core >= 0.10 && < 0.15
+  - servant-client-core >= 0.14 && < 0.15
   - resourcet >= 1.1 && < 1.3
   - streaming >= 0.1 && < 0.3
 
@@ -65,4 +65,4 @@ tests:
       - http-client
       - warp
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.11
+      - QuickCheck >= 2.8 && < 2.12

--- a/servant-streaming-client/servant-streaming-client.cabal
+++ b/servant-streaming-client/servant-streaming-client.cabal
@@ -1,8 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+-- This file has been generated from package.yaml by hpack version 0.21.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: b71d6f6ded7bd45e1d8a989dd9f3daf9f47ad37ac900c89e408f13b55770fa3b
+-- hash: 295159dacfdfa1d79894fdc67a2e46f866c5bb239175b9befa01e702149d85ed
 
 name:           servant-streaming-client
 version:        0.2.0.0
@@ -24,51 +24,51 @@ source-repository head
   location: https://github.com/plow-technologies/servant-streaming
 
 library
+  exposed-modules:
+      Servant.Streaming.Client
+      Servant.Streaming.Client.Internal
   hs-source-dirs:
       src
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <4.11
+      base >=4.7 && <4.12
     , bytestring
     , http-media >=0.6 && <0.8
     , http-types >=0.9 && <0.13
     , resourcet >=1.1 && <1.3
-    , servant >=0.10 && <0.15
-    , servant-client-core >=0.10 && <0.15
+    , servant >=0.14 && <0.15
+    , servant-client-core >=0.14 && <0.15
     , servant-streaming >=0.2 && <0.3
     , streaming >=0.1 && <0.3
-  exposed-modules:
-      Servant.Streaming.Client
-      Servant.Streaming.Client.Internal
   default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
+  other-modules:
+      Servant.Streaming.ClientSpec
+      Paths_servant_streaming_client
   hs-source-dirs:
       test
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall -Wall -with-rtsopts=-T
   build-depends:
-      QuickCheck >=2.8 && <2.11
-    , base >=4.7 && <4.11
+      QuickCheck >=2.8 && <2.12
+    , base >=4.7 && <4.12
     , bytestring
     , hspec >2 && <3
     , http-client
     , http-media >=0.6 && <0.8
     , http-types >=0.9 && <0.13
     , resourcet >=1.1 && <1.3
-    , servant >=0.10 && <0.15
+    , servant >=0.14 && <0.15
     , servant-client
-    , servant-client-core >=0.10 && <0.15
+    , servant-client-core >=0.14 && <0.15
     , servant-server
     , servant-streaming >=0.2 && <0.3
     , servant-streaming-client
     , servant-streaming-server
     , streaming >=0.1 && <0.3
     , warp
-  other-modules:
-      Servant.Streaming.ClientSpec
-      Paths_servant_streaming_client
   default-language: Haskell2010

--- a/servant-streaming-client/src/Servant/Streaming/Client/Internal.hs
+++ b/servant-streaming-client/src/Servant/Streaming/Client/Internal.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-{-# LANGUAGE CPP #-}
 module Servant.Streaming.Client.Internal where
 
 import           Control.Monad
@@ -40,10 +39,8 @@ instance (HasClient m subapi, RunClient m)
                   | BS.null bs -> writeIORef ref str >> popper
                   | otherwise -> writeIORef ref str >> return bs
         liftIO $ write popper
-#if MIN_VERSION_servant_client_core(0,13,0)
   hoistClientMonad pm _ f cl = \a ->
     hoistClientMonad pm (Proxy :: Proxy subapi) f (cl a)
-#endif
 
 instance (RunClient m )
     => HasClient m (StreamResponse verb status contentTypes) where
@@ -61,6 +58,4 @@ instance (RunClient m )
         unless (BS.null bs) $ do
           S.yield bs
           toStream read'
-#if MIN_VERSION_servant_client_core(0,13,0)
   hoistClientMonad _m _ f cl = f cl
-#endif

--- a/servant-streaming-docs/package.yaml
+++ b/servant-streaming-docs/package.yaml
@@ -16,10 +16,10 @@ tested-with:         GHC == 8.2.2
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.7 && < 4.11
-  - servant >= 0.10 && < 0.14
+  - base >= 4.7 && < 4.12
+  - servant >= 0.13 && < 0.15
   - servant-streaming >= 0.2 && < 0.3
-  - servant-docs >= 0.10 && < 0.14
+  - servant-docs >= 0.11 && < 0.15
   - lens
 
 

--- a/servant-streaming-docs/servant-streaming-docs.cabal
+++ b/servant-streaming-docs/servant-streaming-docs.cabal
@@ -1,8 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+-- This file has been generated from package.yaml by hpack version 0.21.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 74804cef0ef3a3470dcfa0dff03660fc820fa165a1c0bd780a0fdbad7f5eefcd
+-- hash: d7c347b7861f017b9043b9fa65d7683dff068b2c44f8a7f437e5ddc862f5ea81
 
 name:           servant-streaming-docs
 version:        0.2.0.0
@@ -24,17 +24,17 @@ source-repository head
   location: https://github.com/plow-technologies/servant-streaming
 
 library
+  exposed-modules:
+      Servant.Streaming.Docs
+      Servant.Streaming.Docs.Internal
   hs-source-dirs:
       src
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <4.11
+      base >=4.7 && <4.12
     , lens
-    , servant >=0.10 && <0.14
-    , servant-docs >=0.10 && <0.14
+    , servant >=0.13 && <0.15
+    , servant-docs >=0.11 && <0.15
     , servant-streaming >=0.2 && <0.3
-  exposed-modules:
-      Servant.Streaming.Docs
-      Servant.Streaming.Docs.Internal
   default-language: Haskell2010

--- a/servant-streaming-server/package.yaml
+++ b/servant-streaming-server/package.yaml
@@ -16,11 +16,11 @@ tested-with:         GHC == 8.2.2
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.7 && < 4.11
+  - base >= 4.7 && < 4.12
   - bytestring
   - resourcet >= 1.1 && < 1.3
   - servant
-  - servant-server >= 0.8 && < 0.14
+  - servant-server >= 0.13 && < 0.15
   - servant-streaming >= 0.2 && < 0.3
   - streaming >= 0.1 && < 0.3
   - streaming-wai >= 0.1 && < 0.2
@@ -61,7 +61,7 @@ tests:
     dependencies:
       - servant-streaming-server
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.11
+      - QuickCheck >= 2.8 && < 2.12
       - pipes >= 4 && < 5
       - pipes-http >= 1 && < 2
       - streaming-bytestring >= 0.1 && < 0.2

--- a/servant-streaming-server/servant-streaming-server.cabal
+++ b/servant-streaming-server/servant-streaming-server.cabal
@@ -1,8 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+-- This file has been generated from package.yaml by hpack version 0.21.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2c782b81db834803cac4a8b8aeffb9f7e765d9e4097f1acee1d86460c5a266fd
+-- hash: a5d40413ed12e56ae19e4fea5670e81c6279960f935ffc86db994070e2203412
 
 name:           servant-streaming-server
 version:        0.2.0.0
@@ -24,37 +24,40 @@ source-repository head
   location: https://github.com/plow-technologies/servant-streaming-server
 
 library
+  exposed-modules:
+      Servant.Streaming.Server
+      Servant.Streaming.Server.Internal
   hs-source-dirs:
       src
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <4.11
+      base >=4.7 && <4.12
     , bytestring
     , http-media >=0.6 && <0.8
     , http-types >=0.9 && <0.13
     , resourcet >=1.1 && <1.3
     , servant
-    , servant-server >=0.8 && <0.14
+    , servant-server >=0.13 && <0.15
     , servant-streaming >=0.2 && <0.3
     , streaming >=0.1 && <0.3
     , streaming-wai >=0.1 && <0.2
     , wai >=3.0 && <3.3
-  exposed-modules:
-      Servant.Streaming.Server
-      Servant.Streaming.Server.Internal
   default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
+  other-modules:
+      Servant.Streaming.ServerSpec
+      Paths_servant_streaming_server
   hs-source-dirs:
       test
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall -Wall -with-rtsopts=-T -threaded
   build-depends:
-      QuickCheck >=2.8 && <2.11
-    , base >=4.7 && <4.11
+      QuickCheck >=2.8 && <2.12
+    , base >=4.7 && <4.12
     , bytestring
     , directory
     , hspec >2 && <3
@@ -64,7 +67,7 @@ test-suite spec
     , pipes-http >=1 && <2
     , resourcet >=1.1 && <1.3
     , servant
-    , servant-server >=0.8 && <0.14
+    , servant-server >=0.13 && <0.15
     , servant-streaming >=0.2 && <0.3
     , servant-streaming-server
     , streaming >=0.1 && <0.3
@@ -72,7 +75,4 @@ test-suite spec
     , streaming-wai >=0.1 && <0.2
     , wai >=3.0 && <3.3
     , warp >=3.2.4 && <3.3
-  other-modules:
-      Servant.Streaming.ServerSpec
-      Paths_servant_streaming_server
   default-language: Haskell2010

--- a/servant-streaming/package.yaml
+++ b/servant-streaming/package.yaml
@@ -17,9 +17,9 @@ tested-with:         GHC == 8.2.2
 ghc-options: -Wall
 
 dependencies:
-  - base >= 4.7 && < 4.11
+  - base >= 4.7 && < 4.12
   - http-types >= 0.9 && < 0.13
-  - servant >= 0.8 && < 0.14
+  - servant >= 0.13 && < 0.15
 
 default-extensions:
   - AutoDeriveTypeable
@@ -54,4 +54,4 @@ tests:
     dependencies:
       - servant-streaming
       - hspec > 2 && < 3
-      - QuickCheck >= 2.8 && < 2.11
+      - QuickCheck >= 2.8 && < 2.12

--- a/servant-streaming/servant-streaming.cabal
+++ b/servant-streaming/servant-streaming.cabal
@@ -1,8 +1,8 @@
--- This file has been generated from package.yaml by hpack version 0.20.0.
+-- This file has been generated from package.yaml by hpack version 0.21.2.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 74ed850a5125af30d91d2e9b3c6a8b357a3a093de9f73f39f7a126043b33983c
+-- hash: 870d8d0449c8cea78cbcdca612c870d784cbfbd433b2b5ce14884d665bb01d53
 
 name:           servant-streaming
 version:        0.2.0.0
@@ -24,32 +24,32 @@ source-repository head
   location: https://github.com/plow-technologies/servant-streaming
 
 library
+  exposed-modules:
+      Servant.Streaming
   hs-source-dirs:
       src
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      base >=4.7 && <4.11
+      base >=4.7 && <4.12
     , http-types >=0.9 && <0.13
-    , servant >=0.8 && <0.14
-  exposed-modules:
-      Servant.Streaming
+    , servant >=0.13 && <0.15
   default-language: Haskell2010
 
 test-suite spec
   type: exitcode-stdio-1.0
   main-is: Spec.hs
+  other-modules:
+      Paths_servant_streaming
   hs-source-dirs:
       test
   default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables TypeFamilies TypeOperators
   ghc-options: -Wall
   build-depends:
-      QuickCheck >=2.8 && <2.11
-    , base >=4.7 && <4.11
+      QuickCheck >=2.8 && <2.12
+    , base >=4.7 && <4.12
     , hspec >2 && <3
     , http-types >=0.9 && <0.13
-    , servant >=0.8 && <0.14
+    , servant >=0.13 && <0.15
     , servant-streaming
-  other-modules:
-      Paths_servant_streaming
   default-language: Haskell2010

--- a/stack-8.4.3.yaml
+++ b/stack-8.4.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.14
+resolver: nightly-2018-06-17
 packages:
 - servant-streaming/
 - servant-streaming-server/


### PR DESCRIPTION
- Support for GHC 8.4
- Support for servant-0.14
- streaming-client requires servant-0.14 or greater

cc @jkarni 