### PR TITLE
Add Header instances for StreamResponse

### DIFF
--- a/servant-streaming-server/package.yaml
+++ b/servant-streaming-server/package.yaml
@@ -48,6 +48,7 @@ default-extensions:
   - ScopedTypeVariables
   - TypeFamilies
   - TypeOperators
+  - TupleSections
 
 library:
   source-dirs:      src

--- a/servant-streaming-server/servant-streaming-server.cabal
+++ b/servant-streaming-server/servant-streaming-server.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2aa8d9c63e7d52568b9fb551cba5c59bef014b82abb09aa00c0387143a1dc11a
+-- hash: 66162efeeb1f91e06a1f77c2c2d60851b88586bf71cd801d73481907d6f58495
 
 name:           servant-streaming-server
 version:        0.3.0.0
@@ -29,7 +29,7 @@ library
       Servant.Streaming.Server.Internal
   hs-source-dirs:
       src
-  default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
+  default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators TupleSections
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <4.13
@@ -53,7 +53,7 @@ test-suite spec
       Paths_servant_streaming_server
   hs-source-dirs:
       test
-  default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators
+  default-extensions: AutoDeriveTypeable ConstraintKinds DataKinds DefaultSignatures DeriveFoldable DeriveFunctor DeriveGeneric DeriveTraversable FlexibleContexts FlexibleInstances FunctionalDependencies GADTs KindSignatures MultiParamTypeClasses OverloadedStrings RankNTypes ScopedTypeVariables TypeFamilies TypeOperators TupleSections
   ghc-options: -Wall -Wall -with-rtsopts=-T -threaded
   build-depends:
       QuickCheck >=2.8 && <2.12


### PR DESCRIPTION
Hey @jkarni - thanks so much for the help on IRC. I think this is the last bit missing:

```
Servant/Streaming/Server/Internal.hs:86:10: error:
        * Overlapping instances for GetHeaders (Headers hs a0)
          Matching givens (or their superclasses):
            GetHeaders (Headers hs a)
              bound by an instance declaration:
                         forall (status :: ghc-prim-0.5.2.0:GHC.Types.Nat) (contentTypes :: [*]) (method :: StdMethod) (hs :: [*]) a (ctx :: [*]).
                         (KnownNat status, AllMime contentTypes, ReflectMethod method,
                          GetHeaders (Headers hs a)) =>
                         HasServer
                           (Headers hs (StreamResponse method status contentTypes)) ctx
              at src/Servant/Streaming/Server/Internal.hs:(86,10)-(87,84)
          Matching instances:
            instance Servant.API.ResponseHeaders.GetHeaders' hs =>
                     GetHeaders (Headers hs a)
              -- Defined in `Servant.API.ResponseHeaders'
          (The choice depends on the instantiation of `hs, a0')
        * In the ambiguity check for an instance declaration
          To defer the ambiguity check to use sites, enable AllowAmbiguousTypes
          In the instance declaration for
            `HasServer (Headers hs (StreamResponse method status contentTypes)) ctx'
       |
    86 | instance ( KnownNat status, AllMime contentTypes, ReflectMethod method, GetHeaders (Headers hs a)
       |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
    
```